### PR TITLE
シェルスクリプトの改善

### DIFF
--- a/sh/create_keystore_debug.sh
+++ b/sh/create_keystore_debug.sh
@@ -1,4 +1,14 @@
-# debug
-keytool -genkey -v -keystore android/debug.jks -alias androiddebugkey -keyalg RSA -validity 10000 -dname "CN=Android Debug,O=Android,C=JA"
-keytool -list -v -alias androiddebugkey -keystore android/debug.jks
-keytool -exportcert -alias androiddebugkey -keystore android/debug.jks | openssl sha1 -binary | openssl base64
+SCRIPT_DIR="$(dirname "$0")"
+KEY_ALIAS="androiddebugkey"
+PASSWORD="password"
+JKS_FILE="../android/debug.jks"
+
+cd $SCRIPT_DIR
+
+if [ -e $JKS_FILE ]; then
+    rm $JKS_FILE
+fi
+
+keytool -genkey -v -keystore $JKS_FILE -alias $KEY_ALIAS -storepass $PASSWORD -keypass $PASSWORD -keyalg RSA -validity 10000 -dname "CN=Android Debug,O=Android,C=JP"
+keytool -list -v -alias $KEY_ALIAS -keystore $JKS_FILE -storepass $PASSWORD
+keytool -exportcert -alias $KEY_ALIAS -storepass $PASSWORD -keystore $JKS_FILE | openssl sha1 -binary | openssl base64

--- a/sh/create_keystore_release.sh
+++ b/sh/create_keystore_release.sh
@@ -1,4 +1,28 @@
-# release
-keytool -genkey -v -keystore android/release.jks -alias alias_name -keyalg RSA -validity 10000
-keytool -list -v -keystore android/release.jks
-keytool -exportcert -alias alias_name -keystore android/release.jks | openssl sha1 -binary | openssl base64
+SCRIPT_DIR="$(dirname "$0")"
+KEY_ALIAS="key"
+# ランダムに生成された16桁のパスワード
+PASSWORD="$(openssl rand -base64 12 | fold -w 16 | head -1)"
+JKS_FILE="../android/release.jks"
+PROPERTIES_FILE="../android/key.properties"
+
+cd $SCRIPT_DIR
+
+if [ -e $PROPERTIES_FILE ]; then
+    rm $PROPERTIES_FILE
+fi
+
+if [ -e $JKS_FILE ]; then
+    rm $JKS_FILE
+fi
+
+keytool -genkey -v -keystore $JKS_FILE -alias $KEY_ALIAS -storepass $PASSWORD -keypass $PASSWORD -keyalg RSA -keysize 2048 -validity 10000 -dname "C=JP"
+keytool -list -v -keystore $JKS_FILE -storepass $PASSWORD
+keytool -exportcert -alias $KEY_ALIAS -storepass $PASSWORD -keystore $JKS_FILE | openssl sha1 -binary | openssl base64
+
+# android/key.propertiesのファイルの中身を空にする
+touch $PROPERTIES_FILE
+: > $PROPERTIES_FILE
+echo "storePassword=$PASSWORD" >> $PROPERTIES_FILE
+echo "keyPassword=$PASSWORD" >> $PROPERTIES_FILE
+echo "keyAlias=$KEY_ALIAS" >> $PROPERTIES_FILE
+echo "storeFile=../release.jks" >> $PROPERTIES_FILE

--- a/sh/run_build_runner.sh
+++ b/sh/run_build_runner.sh
@@ -1,2 +1,2 @@
-flutter packages pub run build_runner build
-#flutter packages pub run build_runner build --delete-conflicting-outputs
+flutter pub run build_runner build
+#flutter pub run build_runner build --delete-conflicting-outputs

--- a/sh/run_build_runner_watch.sh
+++ b/sh/run_build_runner_watch.sh
@@ -1,0 +1,2 @@
+flutter pub run build_runner watch
+# flutter pub run build_runner watch --delete-conflicting-outputs


### PR DESCRIPTION
# 作業内容

- `sh/run_build_runner_watch.sh`を追加
  - build runnerを裏で起動しっぱなしにしておき、変更を検知して自動生成処理を実行してくれます
- `sh/create_keystore_debug.sh`, `sh/create_keystore_release.sh`の改善
  - 各種変数を定義
  - releaseの方は16桁のパスワードを生成して`android/key.properties`も自動で作成されるように変更