### PR TITLE
キーボードのフォーカスを外す処理修正

### DIFF
--- a/lib/extensions/context_extension.dart
+++ b/lib/extensions/context_extension.dart
@@ -20,7 +20,14 @@ extension ContextExtension on BuildContext {
 
   Color get scaffoldBackgroundColor => Theme.of(this).scaffoldBackgroundColor;
 
-  void hideKeyboard() => FocusScope.of(this).unfocus();
+  void hideKeyboard() {
+    // https://github.com/flutter/flutter/issues/54277#issuecomment-640998757
+    final currentScope = FocusScope.of(this);
+    if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
+      FocusManager.instance.primaryFocus!.unfocus();
+    }
+  }
+
   void showSnackBar(
     String text, {
     Color backgroundColor = ColorName.primary,


### PR DESCRIPTION
# 作業内容

`FocusScope.of(context).unfocus()`だとドロワーを開いた時に再度フォーカスされてしまうバグがあるようです。
下のリンク先で解決策として提示されていたコードに修正しました。

参考:
ttps://github.com/flutter/flutter/issues/54277#issuecomment-640998757