### PR TITLE
Fix error handling on shared preference

### DIFF
--- a/lib/model/repositories/shared_preferences/shared_preference_repository.dart
+++ b/lib/model/repositories/shared_preferences/shared_preference_repository.dart
@@ -27,7 +27,7 @@ class SharedPreferencesRepository {
     if (value is List<String>) {
       return _prefs.setStringList(key.value, value);
     }
-    return false;
+    throw UnsupportedError('Not support \'$value\'');
   }
 
   T? fetch<T>(SharedPreferencesKey key) {


### PR DESCRIPTION
# 対応内容
- SharedPreferenceのsaveメソッドの引数に`Set型`や`Map型`など、SharedPreferenceが対応していない型を利用された際にErrorメッセージが出力されるように修正