### PR TITLE
Change json_serializable setting

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,22 @@
 targets:
   $default:
     builders:
+      json_serializable:
+        options:
+          # Options configure how source code is generated for every
+          # `@JsonSerializable`-annotated class in the package.
+          #
+          # The default value for each is listed.
+          any_map: false
+          checked: true # false -> true
+          create_factory: true
+          create_to_json: true
+          disallow_unrecognized_keys: false
+          explicit_to_json: false
+          field_rename: snake # none -> snake
+          generic_argument_factories: false
+          ignore_unannotated: false
+          include_if_null: true
       freezed:
         generate_for:
           include:


### PR DESCRIPTION
# 対応内容
json_seriazableの設定の変更
- `checked`: `false` → `true`
  - fromJsonの例外発生時の内容を取得
- `field_rename`: `none` → `snake`
  - スネークケースを用いられていた場合、自動的にキャメルケースにリネームする設定
  
この対応が不要だと判断されましたら、closeしちゃってください🙇‍♂️

### 参照
- https://zenn.dev/yamatatsu10969/articles/c4a5f05cc38806