### PR TITLE
add matrix strategy for ci

### DIFF
--- a/.github/workflows/flutter_analyze.yaml
+++ b/.github/workflows/flutter_analyze.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-11, macos-12]
-        flutter-version: [stable, "3.0.5"]
+        flutter-version: [stable, 3.0.5]
 
     name: flutter_analyze
     runs-on: ${{ matrix.os }}
@@ -24,7 +24,7 @@ jobs:
       - name: set up flutter
         uses: subosito/flutter-action@v2.6.1
         with:
-          channel: ${{ matrix.os }}
+          channel: ${{ matrix.flutter-version }}
           cache: false
       - name: flutter doctor
         run: flutter doctor -v

--- a/.github/workflows/flutter_analyze.yaml
+++ b/.github/workflows/flutter_analyze.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-11, macos-12]
-        flutter-version: [stable, 3.0.5]
+        flutter-version: [stable, "3.0.5"]
 
     name: flutter_analyze
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/flutter_analyze.yaml
+++ b/.github/workflows/flutter_analyze.yaml
@@ -13,8 +13,8 @@ jobs:
   lint:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-        flutter-channel: [stable, dev, beta, master]
+        os: [windows-latest, ubuntu-latest, macos-11, macos-12]
+        flutter-version: [stable, 3.0.5]
 
     name: flutter_analyze
     runs-on: ${{ matrix.os }}
@@ -24,7 +24,7 @@ jobs:
       - name: set up flutter
         uses: subosito/flutter-action@v2.6.1
         with:
-          channel: ${{ matrix.flutter-channel }}
+          channel: ${{ matrix.os }}
           cache: false
       - name: flutter doctor
         run: flutter doctor -v

--- a/.github/workflows/flutter_analyze.yaml
+++ b/.github/workflows/flutter_analyze.yaml
@@ -11,15 +11,20 @@ on:
 
 jobs:
   lint:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        flutter-channel: [stable, dev, beta, master]
+
     name: flutter_analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: set up repository
         uses: actions/checkout@v3
       - name: set up flutter
         uses: subosito/flutter-action@v2.6.1
         with:
-          channel: "stable"
+          channel: ${{ matrix.flutter-channel }}
           cache: false
       - name: flutter doctor
         run: flutter doctor -v

--- a/.github/workflows/flutter_analyze.yaml
+++ b/.github/workflows/flutter_analyze.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-11, macos-12]
-        flutter-version: [stable, 3.0.5]
+        flutter-version: [stable]
 
     name: flutter_analyze
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
# 変更内容
Flutterの静的解析をmacos-11, macos-12, ubuntu-latest, windows-latest で行えるように変更しました。

# 変更意図
- macosだけでなく、windwosやubuntuプラットフォームのユーザーがこのテンプレートを使用する可能性があるため。
- OSSのCIは使い放題なので、使えるだけ使いたいから。笑